### PR TITLE
Fix database cleanup table name in test_utils.rs

### DIFF
--- a/backend/crates/econ-graph-core/src/test_utils.rs
+++ b/backend/crates/econ-graph-core/src/test_utils.rs
@@ -132,7 +132,7 @@ impl TestContainer {
         // Clean all tables in the correct order (respecting foreign key constraints)
         let tables = vec![
             "crawl_attempts",
-            "crawl_queue_items",
+            "crawl_queue",
             "data_points",
             "economic_series",
             "data_sources",


### PR DESCRIPTION
## Overview

This PR fixes a critical bug in the database cleanup method that was causing test pollution across all test suites.

## Problem

The `clean_database()` method in `test_utils.rs` was using an incorrect table name:
- **Incorrect**: `crawl_queue_items`
- **Correct**: `crawl_queue`

This caused database cleanup to fail silently, leading to test pollution where tests were interfering with each other.

## Root Cause

The table name mismatch meant that:
1. Database cleanup was not properly clearing the `crawl_queue` table
2. Tests were leaving data behind that affected subsequent tests
3. This caused flaky test failures and test isolation issues

## Solution

Fixed the table name in the `clean_database()` method:

```rust
// Before (incorrect)
let tables = vec![
    "crawl_attempts",
    "crawl_queue_items",  // ❌ Wrong table name
    "data_points",
    // ...
];

// After (correct)  
let tables = vec![
    "crawl_attempts",
    "crawl_queue",        // ✅ Correct table name
    "data_points",
    // ...
];
```

## Impact

This fix resolves test pollution issues affecting:
- ✅ **Queue service tests** - Now properly isolated
- ✅ **Auth integration tests** - No longer affected by leftover data
- ✅ **Global analysis tests** - Clean database state between tests
- ✅ **All other test suites** - Improved test reliability

## Testing

After this fix:
- All queue service tests pass consistently
- Auth integration tests pass without interference
- Global analysis tests have proper isolation
- Test suites no longer have flaky failures due to data pollution

## Files Modified

- `backend/crates/econ-graph-core/src/test_utils.rs` - Fixed table name in cleanup method

This is a critical bug fix that should be merged first as it affects the reliability of all other tests.