### PR TITLE
Remove video references from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,57 +7,6 @@
 [![Frontend](https://img.shields.io/badge/Frontend-React%20%2B%20TypeScript-blue)](https://github.com/jmalicki/econ-graph/tree/main/frontend)
 [![License](https://img.shields.io/badge/License-MS--RSL-red.svg)](LICENSE)
 
-## 🎬 **FULLY AUTOMATED 20-MINUTE INVESTOR VIDEO**
-
-> **🚀 COMPLETELY AUTOMATED: Professional investor demo with live preview - just sit back and watch!**
-
-### 🏆 **COMPREHENSIVE 20-MINUTE DEMO VIDEO WITH LIVE AUDIO**
-[![EconGraph Comprehensive Demo](https://img.shields.io/badge/▶️%20WATCH%20COMPREHENSIVE%20DEMO-20%20Minutes%20%7C%20Every%20Feature-red?style=for-the-badge&logo=video&logoColor=white)](./demo-videos/econ-graph-comprehensive-20min-browser-demo.mp4)
-
-**[▶️ WATCH 20-MINUTE COMPREHENSIVE DEMO - EVERY FEATURE SHOWCASED](./demo-videos/econ-graph-comprehensive-20min-browser-demo.mp4)**
-
-### 🎬 **Quick Browser Demo (45 seconds)**
-[![EconGraph Browser Demo](https://img.shields.io/badge/▶️%20QUICK%20DEMO-45%20Seconds%20%7C%20Browser%20Only-green?style=for-the-badge&logo=video&logoColor=white)](./demo-videos/econ-graph-browser-demo.mp4)
-
-**[▶️ Watch Quick Demo - Browser Window Only](./demo-videos/econ-graph-browser-demo.mp4)**
-
-### 🎬 **Automated Video Creation System**
-[![EconGraph Automated System](https://img.shields.io/badge/🤖%20CREATE%20MORE%20VIDEOS-Automated%20System-blue?style=for-the-badge&logo=video&logoColor=white)](./demo-tools/create-automated-20min-investor-video.sh)
-
-**[🎯 Create Additional Videos - Automated System](./demo-tools/create-automated-20min-investor-video.sh)**
-
-> **🤖 FULLY AUTOMATED SYSTEM: Complete 20-minute investor demo that runs itself! Features professional British narration, automated UI interactions, live preview in QuickTime, and comprehensive business presentation. Just run the script and watch - perfect for investors, board meetings, and customer demos.**
-
-### ✅ **Comprehensive 20-Minute Demo Features:**
-- **🎯 Every Feature Showcased**: Complete walkthrough of all EconGraph capabilities
-- **🎵 Live Audio Experience**: British narration plays during recording for synchronized demo
-- **🔒 Privacy Secure**: Browser window only (1500x920) - no desktop visible
-- **⏱️ Professional Length**: 8+ minutes of comprehensive feature demonstration
-- **💻 Real Application**: Live React frontend with all components functioning
-- **⚡ Full Stack Demo**: Rust + GraphQL + PostgreSQL backend in action
-- **📊 Complete Features**: Search, charts, transformations, collaboration, global analysis
-- **🎬 9 Demo Phases**: Landing → Navigation → Search → Charts → Transformations → Collaboration → Global → Data Sources → Summary
-
-### 🎬 **Automated Creation System Features:**
-- **📹 Live Preview**: Watch recording happen in real-time in QuickTime
-- **🤖 Automated UI**: Fully scripted React app interactions with visual feedback
-- **👁️ Visual Overlays**: Live status updates and progress tracking during demo
-- **🚀 Zero Setup**: Automatic backend/frontend startup and browser automation
-
-**🎯 Full 20-Minute Structure:**
-- **[0-4min]** Opening & Market Analysis (landing page, $8.2B market opportunity, disruption)
-- **[4-8min]** Technology Foundation Deep Dive (Rust/React/GraphQL, performance, architecture)
-- **[8-13min]** Core Features Demo (search, charts, bug fixes, transformations, comparisons)
-- **[13-16min]** Data Sources & Quality (FRED, BLS, API access, metadata)
-- **[16-18min]** Business Model & Strategy (pricing, 90% cost savings, enterprise features)
-- **[18-19.5min]** Competitive Advantages (open source, modern UX, customization)
-- **[19.5-20min]** Investment Opportunity ($2M Series A, growth strategy, ROI)
-
-**📊 Perfect for:**
-- **Investor Presentations** - Complete business case with professional narration
-- **Board Meetings** - Technical depth with business strategy
-- **Demo Days** - Comprehensive feature showcase with market positioning
-- **Fundraising** - Clear investment opportunity and growth potential
 
 ## 💰 **DEVELOPMENT COST TRANSPARENCY**
 
@@ -97,38 +46,7 @@
 
 ---
 
-## 🎬 **PROTOTYPE DEMONSTRATIONS**
-
-> **Honest demos showing actual implemented features**
-
-### 💼 **Real UI Business Demo - Working App + Business Case**
-[![EconGraph Real UI Business Demo](https://img.shields.io/badge/💼%20Real%20UI%20Business%20Demo-Working%20App%20%2B%20Business%20Case-brightgreen?style=for-the-badge&logo=play)](https://github.com/jmalicki/econ-graph/raw/main/demo-videos/real-ui-business-demo.mp4)
-
-**[🚀 Create Your Own Real UI Business Demo](./demo-tools/create-real-ui-business-demo.sh)**
-
-> **✅ REAL WORKING APPLICATION: Shows the actual React app running at localhost:3000 with live interactions, business value demonstration, and professional UI usage. No mockups - just real software being used.**
-
-**🎯 What You'll See:**
-- **Live React Application** running in browser with real interactions
-- **Business Value Demonstration** showing ROI and use cases for economists
-- **Working Features** with actual clicking, searching, and chart interactions
-- **Professional UI** with Material-UI components in real usage
-- **Technical Capabilities** including GraphQL API calls and responsive design
-- **Future Roadmap** highlighting ML and advanced analytics potential
-
-### 🌍 **Real Interface Demo - Actual React Application**
-[![EconGraph Real Interface Demo](https://img.shields.io/badge/🌍%20Real%20Interface%20Demo-Actual%20React%20Application-brightgreen?style=for-the-badge&logo=play)](https://github.com/jmalicki/econ-graph/raw/main/demo-videos/real-econ-graph-interface.mp4)
-
-**[📺 Watch the REAL Interface Demo - 77sec HD Screen Recording](https://github.com/jmalicki/econ-graph/raw/main/demo-videos/real-econ-graph-interface.mp4)**
-
-> **✅ ACTUAL PROTOTYPE: Shows the real running React application with genuine Material-UI components, working navigation, and functional interface elements.**
-
-### 🤝 **Collaboration Features Demo**
-[![EconGraph Enhanced Collaboration Demo](https://img.shields.io/badge/🤝%20Enhanced%20Collaboration%20Demo-Team%20Workflow%20Features-blue?style=for-the-badge&logo=play)](https://github.com/jmalicki/econ-graph/raw/main/demo-videos/collaboration-demo-with-narration.mp3)
-
-**[📺 Watch the Collaboration Demo with Audio](https://github.com/jmalicki/econ-graph/raw/main/demo-videos/collaboration-demo-with-narration.mp3)**
-
-### ✨ **Actually Implemented Features:**
+## ✨ **Actually Implemented Features:**
 - **🌍 React Frontend** - Working React application with Material-UI components
 - **📊 Interactive Charts** - Chart.js integration with hover tooltips and zoom
 - **🔄 Data Transformations** - Year-over-Year (YoY), Quarter-over-Quarter (QoQ), Month-over-Month (MoM)
@@ -136,16 +54,6 @@
 - **🔍 Search & Filtering** - Full-text search with autocomplete and filtering
 - **📈 Time Series Visualization** - Economic data plotting with date range selection
 - **🏗️ Database Integration** - PostgreSQL with Diesel ORM for data persistence
-
-### 🎯 **What You'll See in the Real Interface Demo:**
-- 🌍 **Live React Application**: Actual browser window showing the running EconGraph interface
-- 📊 **Material-UI Components**: Real buttons, navigation, cards, and layouts in action
-- 📈 **Working Navigation**: Functional React Router with live page transitions
-- 🎛️ **Interactive Elements**: Real clickable components and working state management
-- 🏷️ **Professional Styling**: Actual Material-UI theme with responsive design
-- 🎤 **Honest Narration**: 77-second description of what's actually implemented
-- 🎯 **Zero Fake Content**: No text overlays, Unicode boxes, or static mockups
-- ✅ **Genuine Demonstration**: Authentic screen recording of the actual running application
 
 ---
 
@@ -350,27 +258,6 @@ EconGraph maintains the highest standards of quality and reliability expected by
 
 5. **🎉 Open your browser** to `http://localhost:3000`
 
-### **🎬 Create Demo Videos**
-```bash
-# Navigate to demo tools
-cd demo-tools
-
-# 🚀 RECOMMENDED: Create real UI business demo
-./create-real-ui-business-demo.sh
-
-# Create realistic demo showing actual features
-./create-realistic-demo.sh
-
-# Create honest pitch video
-./create-honest-pitch-video.sh
-```
-
-**🎯 For the best demo experience:**
-1. **Run the Real UI Business Demo** - shows actual working app + business case
-2. **Record yourself using the interface** - demonstrates real functionality
-3. **Follow the provided script** - ensures professional presentation
-
-**📁 All demo tools available in:** [`demo-tools/`](./demo-tools/) directory
 
 ---
 
@@ -483,9 +370,7 @@ This project is licensed under the Microsoft Reference Source License (MS-RSL) -
 
 ### 🎯 **Ready to explore this economic data visualization prototype?**
 
-**[🌍 Watch Real Interface Demo](https://github.com/jmalicki/econ-graph/raw/main/demo-videos/real-econ-graph-interface.mp4)** • **[🚀 Try the Live Demo](#getting-started)** • **[📚 Read the Code](https://github.com/jmalicki/econ-graph)**
-
-> **📺 Real Interface Demo - ACTUAL screen recording of the working React prototype**
+**[🚀 Try the Live Demo](#getting-started)** • **[📚 Read the Code](https://github.com/jmalicki/econ-graph)**
 
 ---
 


### PR DESCRIPTION
## 📝 README.md Cleanup: Remove Video References

This PR removes all video references from the main README.md file to clean up the documentation and focus on technical content.

### 🗑️ **Sections Removed:**
- **'FULLY AUTOMATED 20-MINUTE INVESTOR VIDEO'** section (lines 10-30)
- **'PROTOTYPE DEMONSTRATIONS'** section with video links (lines 100-149)
- **'Create Demo Videos'** section from Getting Started (lines 353-374)
- **Video links from footer** (lines 486-488)

### ✅ **Content Preserved:**
- **Product Overview** - Core product information and features
- **Technology Leadership** - Technical architecture details
- **Getting Started** - Setup and installation instructions
- **Project Structure** - Codebase organization
- **Performance** - Technical metrics and capabilities
- **License & Usage** - Legal information

### 🎯 **Benefits:**
- **Cleaner Documentation** - Focus on technical content without video distractions
- **Reduced Maintenance** - No need to maintain video links and references
- **Professional Appearance** - README focuses on code and technical capabilities
- **Consistent Structure** - Maintains logical flow without video sections

### 📊 **Changes Summary:**
- **117 lines removed** (video-related content)
- **2 lines added** (cleanup)
- **Net reduction:** 115 lines
- **No breaking changes** to core documentation

### 🧪 **Testing:**
- All pre-commit hooks passed
- Markdown linting passed
- No broken internal links
- README structure maintained