### PR TITLE
Move development cost transparency above project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,44 +134,6 @@ EconGraph is a **production-ready economic data intelligence platform** that tra
 
 ---
 
-## 💰 **DEVELOPMENT COST TRANSPARENCY**
-
-> **AI-Assisted Development with Cursor - Comprehensive Cost Analysis**
-
-### 📊 **Cursor AI Usage Statistics (Aug 12 - Sep 9, 2025)**
-- **Total AI Interactions**: 347 requests
-- **Total Tokens Processed**: **517.1M tokens** 
-- **Success Rate**: 77.5% (269 successful, 78 errored)
-- **Average Request Size**: 1.49M tokens
-- **Peak Development Day**: Sep 5, 2025 (155.8M tokens)
-- **Development Period**: 28 days of active AI-assisted coding
-
-### 💵 **Actual Development Costs**
-- **Cursor Pro Subscription**: ~$20/month
-- **Estimated Token Costs**: $258-$1,034 (at $0.50-$2.00 per 1M tokens)
-- **Total Project Cost**: $278-$1,054
-- **Daily Average**: $9.21-$36.86
-- **Cost per Major Feature**: ~$50-$200
-
-### ⚡ **ROI & Efficiency Analysis**
-- **🏗️ Features Delivered**: 15+ major components (React frontend, Rust backend, GraphQL API, collaboration features, global analysis, CI/CD pipelines)
-- **📝 Lines of Code**: 50,000+ across frontend/backend with comprehensive documentation
-- **⏰ Time Saved**: Estimated 200+ hours vs traditional solo development
-- **🚀 Development Speed**: 10-20x faster iteration cycles
-- **✅ Quality Achieved**: Professional-grade testing, documentation, security scanning
-
-### 🎯 **Major Achievements with AI Assistance**
-- **Frontend**: Complete React/TypeScript app with Material-UI, Chart.js, routing
-- **Backend**: Rust/Axum server with GraphQL, PostgreSQL, Diesel ORM, Docker
-- **Testing**: 157+ passing tests (unit, integration, e2e) with testcontainers
-- **CI/CD**: GitHub Actions workflows with security scanning, formatting, linting
-- **Documentation**: Google-style comments, comprehensive README, investor pitch
-- **Features**: Real-time collaboration, economic data visualization, transformations
-
-> **💡 TRANSPARENCY INSIGHT**: This project demonstrates that AI-assisted development can deliver enterprise-quality results at a fraction of traditional costs. The $278-$1,054 total investment produced a full-stack application that would typically require $50,000-$100,000 in development costs and 6-12 months with a traditional team.
-
----
-
 ## 🎯 **Product Quality & Reliability**
 
 ### **📊 Enterprise-Grade Quality Assurance**
@@ -284,6 +246,43 @@ EconGraph maintains the highest standards of quality and reliability expected by
 
 5. **🎉 Open your browser** to `http://localhost:3000`
 
+---
+
+## 💰 **DEVELOPMENT COST TRANSPARENCY**
+
+> **AI-Assisted Development with Cursor - Comprehensive Cost Analysis**
+
+### 📊 **Cursor AI Usage Statistics (Aug 12 - Sep 9, 2025)**
+- **Total AI Interactions**: 347 requests
+- **Total Tokens Processed**: **517.1M tokens** 
+- **Success Rate**: 77.5% (269 successful, 78 errored)
+- **Average Request Size**: 1.49M tokens
+- **Peak Development Day**: Sep 5, 2025 (155.8M tokens)
+- **Development Period**: 28 days of active AI-assisted coding
+
+### 💵 **Actual Development Costs**
+- **Cursor Pro Subscription**: ~$20/month
+- **Estimated Token Costs**: $258-$1,034 (at $0.50-$2.00 per 1M tokens)
+- **Total Project Cost**: $278-$1,054
+- **Daily Average**: $9.21-$36.86
+- **Cost per Major Feature**: ~$50-$200
+
+### ⚡ **ROI & Efficiency Analysis**
+- **🏗️ Features Delivered**: 15+ major components (React frontend, Rust backend, GraphQL API, collaboration features, global analysis, CI/CD pipelines)
+- **📝 Lines of Code**: 50,000+ across frontend/backend with comprehensive documentation
+- **⏰ Time Saved**: Estimated 200+ hours vs traditional solo development
+- **🚀 Development Speed**: 10-20x faster iteration cycles
+- **✅ Quality Achieved**: Professional-grade testing, documentation, security scanning
+
+### 🎯 **Major Achievements with AI Assistance**
+- **Frontend**: Complete React/TypeScript app with Material-UI, Chart.js, routing
+- **Backend**: Rust/Axum server with GraphQL, PostgreSQL, Diesel ORM, Docker
+- **Testing**: 157+ passing tests (unit, integration, e2e) with testcontainers
+- **CI/CD**: GitHub Actions workflows with security scanning, formatting, linting
+- **Documentation**: Google-style comments, comprehensive README, investor pitch
+- **Features**: Real-time collaboration, economic data visualization, transformations
+
+> **💡 TRANSPARENCY INSIGHT**: This project demonstrates that AI-assisted development can deliver enterprise-quality results at a fraction of traditional costs. The $278-$1,054 total investment produced a full-stack application that would typically require $50,000-$100,000 in development costs and 6-12 months with a traditional team.
 
 ---
 


### PR DESCRIPTION
## 📝 README.md Section Repositioning

This PR moves the 'Development Cost Transparency' section to just above the 'Project Structure' section for better README flow.

### 🎯 **Changes Made:**

#### 📍 **Moved Development Cost Transparency Section**
- **New Location**: Just above 'Project Structure' section
- **Previous Location**: After 'Target Users & Use Cases' section
- **Better Flow**: Overview → Features → Users → Quality → Getting Started → Development Costs → Project Structure

### 🎯 **Benefits:**
- **Better Positioning**: Development costs appear after getting started instructions but before technical project details
- **Logical Flow**: Readers understand the product, then how to use it, then how it was built, then the code structure
- **Improved Readability**: Development approach is positioned before diving into technical project structure
- **Maintained Content**: All existing information preserved with improved organization

### 📊 **New Section Order:**
1. **What EconGraph Does** - Product overview and capabilities
2. **Actually Implemented Features** - Technical features
3. **Product Overview** - Detailed product information
4. **Target Users & Use Cases** - User personas and use cases
5. **Product Quality & Reliability** - Quality assurance
6. **Technology Leadership** - Technical architecture
7. **Getting Started** - Setup instructions
8. **Development Cost Transparency** (MOVED) - AI-assisted development costs
9. **Project Structure** - Codebase organization
10. **Performance** - Technical metrics
11. **License & Usage** - Legal information

### 🧪 **Testing:**
- All pre-commit hooks passed
- Markdown linting passed
- No broken internal links
- Content structure improved while maintaining all information