### PR TITLE
fix: remove Update Cost Analysis workflow from running on push

### DIFF
--- a/.github/workflows/update-cost-analysis.yml
+++ b/.github/workflows/update-cost-analysis.yml
@@ -5,13 +5,6 @@ on:
     # Run daily at 6 AM UTC
     - cron: '0 6 * * *'
   workflow_dispatch:
-  push:
-    paths:
-      - 'data/usage-events-*.csv'
-      - 'scripts/codebase-stats-corrected.sh'
-      - 'scripts/update-cost-analysis.sh'
-      - 'backend/src/**'
-      - 'frontend/src/**'
 
 jobs:
   update-costs:


### PR DESCRIPTION
## Fix: Remove Cost Analysis Workflow from Push Triggers

This PR removes the Update Cost Analysis workflow from running on every push, which was causing unnecessary CI/CD noise and resource usage.

### Problem
- The Update Cost Analysis workflow was configured to run on push to specific paths
- This caused the workflow to run frequently during development
- Unnecessary resource usage and CI/CD noise

### Solution
- **Removed push trigger** from update-cost-analysis.yml workflow
- **Kept scheduled daily run** at 6 AM UTC (still useful for regular updates)
- **Kept manual workflow_dispatch** trigger (for on-demand updates)
- **Reduced CI/CD noise** and resource usage

### Changes Made
- Removed  trigger with path filters from workflow
- Workflow now only runs on:
  - Scheduled daily at 6 AM UTC
  - Manual dispatch (workflow_dispatch)

### Benefits
- ✅ **Reduced CI/CD noise** - no more cost analysis runs on every push
- ✅ **Lower resource usage** - fewer unnecessary workflow runs
- ✅ **Maintained functionality** - still runs daily and can be triggered manually
- ✅ **Better development experience** - less interruption during development

### Testing
- ✅ Pre-commit hooks passed
- ✅ Workflow syntax validated
- ✅ No breaking changes to existing functionality