### PR TITLE
ci: skip backend jobs on frontend-only changes

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -52,9 +52,34 @@ env:
   DATABASE_URL: postgresql://postgres:password@localhost:5432/econ_graph_test
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      frontend_only: ${{ steps.filter.outputs.frontend == 'true' && steps.filter.outputs.backend == 'false' }}
+    steps:
+    - uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          frontend:
+            - 'frontend/**'
+            - 'admin-frontend/**'
+          backend:
+            - 'backend/**'
+            - 'chart-api-service/**'
+            - 'ci/**'
+            - '.github/**'
+            - 'k8s/**'
+            - 'terraform/**'
+            - 'scripts/**'
+            - 'docker-compose.yml'
+            - 'package.json'
   backend-build-cache:
     name: Backend Build Cache
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.frontend_only != 'true'
     timeout-minutes: 90
 
     steps:


### PR DESCRIPTION
Use paths-filter to gate backend jobs when only frontend/admin-frontend changed.