### PR TITLE
Fix CI: Skip change detection entirely on main/develop branches

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -55,20 +55,14 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop'
     outputs:
       frontend_only: ${{ steps.filter.outputs.frontend == 'true' && steps.filter.outputs.backend == 'false' }}
-      run_all_tests: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - name: Set outputs for main/develop branches
-      if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
-      run: |
-        echo "frontend=true" >> $GITHUB_OUTPUT
-        echo "backend=true" >> $GITHUB_OUTPUT
     - uses: dorny/paths-filter@v3
       id: filter
-      if: github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop'
       with:
         base: main
         filters: |
@@ -89,7 +83,7 @@ jobs:
     name: Backend Build Cache
     runs-on: ubuntu-latest
     needs: [changes]
-    if: needs.changes.outputs.run_all_tests == 'true' || needs.changes.outputs.frontend_only != 'true'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || (needs.changes.outputs.frontend_only != 'true')
     timeout-minutes: 90
 
     steps:


### PR DESCRIPTION
## 🔧 Fix CI Change Detection

### Problem
The CI change detection job was still running on main/develop branches, which is unnecessary since we want to always run all tests on these branches.

### Solution
- **Main/Develop branches**: Change detection job is completely skipped
- **Feature branches**: Change detection runs for optimization
- **Simplified logic**: No change detection = no optimization needed

### Changes
- ✅ Added  condition to skip changes job entirely on main/develop
- ✅ Updated backend-build-cache to always run on main/develop
- ✅ Removed unnecessary complexity from change detection logic
- ✅ Cleaner, more efficient CI workflow

### Benefits
- **Faster CI on main**: No unnecessary change detection overhead
- **Always comprehensive**: Main/develop always run all tests
- **Optimized feature branches**: Still get selective testing based on changes
- **Simpler logic**: Easier to understand and maintain